### PR TITLE
Resize bug in IOS 8

### DIFF
--- a/jquery.slimmenu.js
+++ b/jquery.slimmenu.js
@@ -17,6 +17,8 @@
             indentChildren: false,
             childrenIndenter: '&nbsp;&nbsp;'
         };
+        
+    var oldWindowWidth = 0;
 
     function Plugin( element, options )
     {
@@ -75,6 +77,11 @@
                 $options = event.data.options,
                 $menu = $(event.data.el),
                 $menu_collapser = $('body').find('.menu-collapser');
+                
+            if (oldWindowWidth == $window.width()) {
+				return;
+			}
+			oldWindowWidth = $window.width();
 
             $menu.find('li').each(function()
             {


### PR DESCRIPTION
Safari bundled with IOS 8 comes with a new interface that shrinks the location bar and hides the button bar after scrolling. For this reason, the slim menu closes every time the page is scrolled (resize event reset the menu). In order to prevent this, I restricted the reset to window width resizes.